### PR TITLE
Add SQL support for accounts

### DIFF
--- a/accounts.json
+++ b/accounts.json
@@ -1,8 +1,0 @@
-{
-    "lostmc":1000000,
-    "ballas":0,
-    "vagos":0,
-    "cartel":0,
-    "families":0,
-    "triads":0
-}

--- a/qbgangmenu.sql
+++ b/qbgangmenu.sql
@@ -1,0 +1,14 @@
+
+CREATE TABLE IF NOT EXISTS `gangmenu_accounts` (
+    `id` int(11) NOT NULL AUTO_INCREMENT,
+    `account` text NOT NULL,
+    `money` text NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+INSERT INTO `gangmenu_accounts`(`account`, `money`) VALUES('lostmc', '1000000');
+INSERT INTO `gangmenu_accounts`(`account`, `money`) VALUES('ballas', '0');
+INSERT INTO `gangmenu_accounts`(`account`, `money`) VALUES('vagos', '0');
+INSERT INTO `gangmenu_accounts`(`account`, `money`) VALUES('cartel', '0');
+INSERT INTO `gangmenu_accounts`(`account`, `money`) VALUES('families', '0');
+INSERT INTO `gangmenu_accounts`(`account`, `money`) VALUES('triads', '0');

--- a/server.lua
+++ b/server.lua
@@ -33,7 +33,7 @@ function UpdateAccountMoney(account, money)
 end
 
 -- Withdraw Money
-RegisterServerEvent("qb-gangmenu:server:withdrawMoney")
+RegisterNetEvent("qb-gangmenu:server:withdrawMoney")
 AddEventHandler("qb-gangmenu:server:withdrawMoney", function(amount)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
@@ -56,7 +56,7 @@ AddEventHandler("qb-gangmenu:server:withdrawMoney", function(amount)
 end)
 
 -- Deposit Money
-RegisterServerEvent("qb-gangmenu:server:depositMoney")
+RegisterNetEvent("qb-gangmenu:server:depositMoney")
 AddEventHandler("qb-gangmenu:server:depositMoney", function(amount)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
@@ -77,7 +77,7 @@ AddEventHandler("qb-gangmenu:server:depositMoney", function(amount)
         "Successfully deposited $" .. amount .. ' (' .. gang .. ')', src)
 end)
 
-RegisterServerEvent("qb-gangmenu:server:addAccountMoney")
+RegisterNetEvent("qb-gangmenu:server:addAccountMoney")
 AddEventHandler("qb-gangmenu:server:addAccountMoney", function(account, amount)
     if not Accounts[account] then
         Accounts[account] = 0
@@ -88,7 +88,7 @@ AddEventHandler("qb-gangmenu:server:addAccountMoney", function(account, amount)
     UpdateAccountMoney(account, Accounts[account])
 end)
 
-RegisterServerEvent("qb-gangmenu:server:removeAccountMoney")
+RegisterNetEvent("qb-gangmenu:server:removeAccountMoney")
 AddEventHandler("qb-gangmenu:server:removeAccountMoney", function(account, amount)
     if not Accounts[account] then
         Accounts[account] = 0
@@ -135,7 +135,7 @@ QBCore.Functions.CreateCallback('qb-gangmenu:server:GetEmployees', function(sour
 end)
 
 -- Grade Change
-RegisterServerEvent('qb-gangmenu:server:updateGrade')
+RegisterNetEvent('qb-gangmenu:server:updateGrade')
 AddEventHandler('qb-gangmenu:server:updateGrade', function(target, grade)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
@@ -165,7 +165,7 @@ AddEventHandler('qb-gangmenu:server:updateGrade', function(target, grade)
 end)
 
 -- Fire Employee
-RegisterServerEvent('qb-gangmenu:server:fireEmployee')
+RegisterNetEvent('qb-gangmenu:server:fireEmployee')
 AddEventHandler('qb-gangmenu:server:fireEmployee', function(target)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
@@ -203,7 +203,7 @@ AddEventHandler('qb-gangmenu:server:fireEmployee', function(target)
 end)
 
 -- Recruit Player
-RegisterServerEvent('qb-gangmenu:server:giveJob')
+RegisterNetEvent('qb-gangmenu:server:giveJob')
 AddEventHandler('qb-gangmenu:server:giveJob', function(recruit)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)


### PR DESCRIPTION
This commit removes the use of the 'accounts.json' file and replaces it with SQL support. This PR was made because of a suggestion in the QBCore Discord from user 'Hyper#7533' to move the accounts.json data into a database table which as of the time this PR was made, had an overwhelming positive rating of 45-4.

I have tested these changes using my own private QBCore testing server created using the TxAdmin recipe for QBCore. I tested depositing and withdrawing money from the 'ballas' account, which worked as expected, with no obvious issues.

This PR also contains a really minor change to the server sided event registration, of which i simply removed the deprecated 'RegisterServerEvent' function.