### PR TITLE
fix injection exploit

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -97,11 +97,12 @@ end)
 -- Get Employees
 QBCore.Functions.CreateCallback('qb-gangmenu:server:GetEmployees', function(source, cb, gangname)
     local src = source
+
     local employees = {}
     if not Accounts[gangname] then
         Accounts[gangname] = 0
     end
-    local players = exports.oxmysql:executeSync("SELECT * FROM `players` WHERE `gang` LIKE '%".. gangname .."%'")
+    local players = exports.oxmysql:executeSync("SELECT * FROM `players` WHERE `gang` = ?", {gangname})
     if players[1] ~= nil then
         for key, value in pairs(players) do
             local isOnline = QBCore.Functions.GetPlayerByCitizenId(value.citizenid)


### PR DESCRIPTION
The current way is open to exploiting, eg if someone with an injector can trigger

```
QBCore.Functions.TriggerCallback("qb-gangmenu:server:GetEmployees", function(result)
end, "%; DROP players; --")
```

It will execute:

`SELECT * FROM `players` WHERE `gang` LIKE '%".. gangname .."%'`

as

`SELECT * FROM `players` WHERE `gang` LIKE '%%; DROP players; --%'"`

Update to change to parameters
This would also apply to `qb-bossmenu`