### PR TITLE
Allow only the boss to access the gang "boss" menu

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -160,7 +160,7 @@ CreateThread(function()
         if PlayerGang.name ~= nil then
             local pos = GetEntityCoords(PlayerPedId())
             for k, v in pairs(Config.Gangs) do
-                if k == PlayerGang.name then
+                if k == PlayerGang.name and PlayerGang.isboss then
                     if #(pos - v) < 1.0 then
                         sleep = 5
                         DrawText3D(v, "~g~E~w~ - Gang Menu")


### PR DESCRIPTION
The changes proposed should fix the fact that anyone within the gang can access the gang menu rather than just the boss.